### PR TITLE
(SIMP-7299) Updates for EL8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Overview
 
 Rake and config files to build/package newer versions of the [IBM TPM 2.0
-simulator][ibmswtpm2] as an EL7 RPM.
+simulator][ibmswtpm2] as an EL7 or EL8 RPM.
 
 ### This is a SIMP project
 
@@ -31,7 +31,7 @@ If you find any issues, please submit them to our [bug tracker][simp-jira].
 
 The TPM 2.0 simulator build process requires:
 
-* An EL7 host with:
+* An EL7 or EL8 host with:
   - `rpm`
   - `tar`
   - `curl` (for direct downloads)
@@ -82,20 +82,30 @@ This will install the simulator programs to utilize the TPM 2.0 simulator.
 To initialize and use the TPM simulator, issue the following commands:
 
 ```yaml
-# runuser tpm2sim --shell /bin/sh -c "cd /tmp; nohup \
-  /usr/local/bin/tpm2-simulator &> /tmp/tpm2-simulator.log &"
+# runuser simp-tpm2-sim --shell /bin/sh -c "cd /tmp; nohup \
+  /usr/local/bin/simp-tpm2-simulator &> /tmp/simp-tpm2-simulator.log &"
 # mkdir -p /etc/systemd/system/tpm2-abrmd.service.d
+On EL7 systems:
 # printf "[Service]\nExecStart=\nExecStart=/sbin/tpm2-abrmd -t socket" \
+  > /etc/systemd/system/tpm2-abrmd.service.d/override.conf
+On EL8 systems:
+# printf "[Service]\nExecStart=\nExecStart=/sbin/tpm2-abrmd --tcti mssim" \
   > /etc/systemd/system/tpm2-abrmd.service.d/override.conf
 # systemctl daemon-reload
 # systemctl start tpm2-abrmd
 ```
 
+On systems using SELinux (for example, check with the getenforce utility) the
+default service policy is too restrictive. See INSTALL.md at [TPM2 Access Broker
+& Resource Management Daemon][tpm2-abrmd] for more details.
+
+
 ## Development
 
 Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
 
-[bundler]:   https://bundler.io
-[simp]:      https://www.simp-project.com/
-[simp-jira]: https://simp-project.atlassian.net/
-[ibmswtpm2]: https://sourceforge.net/projects/ibmswtpm2/
+[bundler]:    https://bundler.io
+[simp]:       https://www.simp-project.com/
+[simp-jira]:  https://simp-project.atlassian.net/
+[ibmswtpm2]:  https://sourceforge.net/projects/ibmswtpm2/
+[tpm2-abrmd]: https://github.com/tpm2-software/tpm2-abrmd

--- a/simp-tpm2-simulator/simp-tpm2-simulator.service
+++ b/simp-tpm2-simulator/simp-tpm2-simulator.service
@@ -1,15 +1,16 @@
 # copy this file into /etc/systemd/system
 [Unit]
-Description=TPM2 Simulator
+Description=SIMP Wrapper around the IBM TPM2 Simulator
 
 [Service]
-Type=dbus
+Type=simple
 Restart=no
-EnvironmentFile=-/etc/default/tpm2-simulator
-BusName=com.ibm.tpm2.tpm2-simulator
+Environment=LC_ALL=en_IE
+EnvironmentFile=-/etc/default/simp-tpm2-simulator
 StandardOutput=syslog
-ExecStart=/usr/local/bin/tpm2-simulator
-User=tss
+ExecStart=/usr/local/bin/simp-tpm2-simulator
+User=simp-tpm2-sim
+WorkingDirectory=/tmp
 
 [Install]
 WantedBy=multi-user.target

--- a/simp-tpm2-simulator/simp-tpm2-simulator.spec
+++ b/simp-tpm2-simulator/simp-tpm2-simulator.spec
@@ -11,7 +11,7 @@ Summary: SIMP packaging of the IBM TPM 2.0 simulator
 %global _simulator_user simp-tpm2-sim
 
 License: ASL 2.0 and BSD
-URL:     https://github.com/simp/simp-tpm12-simulator
+URL:     https://github.com/simp/simp-tpm2-simulator
 ###https://sourceforge.net/projects/ibmswtpm2/
 ###https://sourceforge.net/projects/ibmswtpm2/files/ibmtpm%%{version}.tar.gz/download
 Source0: %{name}-%{version}.tar.gz

--- a/simp-tpm2-simulator/simp-tpm2-simulator.spec
+++ b/simp-tpm2-simulator/simp-tpm2-simulator.spec
@@ -3,12 +3,12 @@
 
 Name: simp-tpm2-simulator
 Version: 1332.0.0
-Release: 0%{?dist}
-Summary: The SIMP IBM TPM 2.0 simulator
+Release: 1%{?dist}
+Summary: SIMP packaging of the IBM TPM 2.0 simulator
 
 # SIMP customization:
 %global _prefix /usr/local
-%global _name tpm2-simulator
+%global _simulator_user simp-tpm2-sim
 
 License: ASL 2.0 and BSD
 URL:     https://github.com/simp/simp-tpm12-simulator
@@ -18,7 +18,7 @@ Source0: %{name}-%{version}.tar.gz
 Source1: %{name}.service
 Source2: LICENSE
 
-BuildRequires: gcc-c++
+BuildRequires: gcc-c++ openssl-devel
 
 %description
 IBM's simulator that implements the TCG TPM 2.0 specification. It is based on
@@ -36,45 +36,47 @@ cd src/
 cat %{SOURCE2} > ../LICENSE
 
 %install
-install -m 0755 -D src/tpm_server %{buildroot}%{_bindir}/%{_name}
-install -m 0644 -D %{SOURCE1}     %{buildroot}%{_unitdir}/%{_name}.service
+install -m 0755 -D src/tpm_server %{buildroot}%{_bindir}/%{name}
+install -m 0644 -D %{SOURCE1}     %{buildroot}%{_unitdir}/%{name}.service
 
 %files
 %license LICENSE
 #BSD
 %doc ibmtpm.doc
-%{_bindir}/%{_name}
+%{_bindir}/%{name}
 #ASL 2.0
-%{_unitdir}/%{_name}.service
-
-
+%{_unitdir}/%{name}.service
 
 %pre
 mkdir -p %{_datadir}
 
-getent group tpm2sim >/dev/null || groupadd -g 61 -r tpm2sim
-getent passwd tpm2sim >/dev/null || \
-useradd -r -u 61 -g tpm2sim -d /dev/null -s /sbin/nologin \
- -c "Account used by the simp-tpm2-simulator package to sandbox the simp-tpm2-simulator daemon" tpm2sim
+getent group %{_simulator_user} >/dev/null || groupadd -r %{_simulator_user}
+getent passwd %{_simulator_user} >/dev/null || \
+useradd -r -g %{_simulator_user} -d /dev/null -s /sbin/nologin \
+ -c "Account used by the %{name} package to sandbox the %{name} daemon" %{_simulator_user}
 exit 0
 
 %post
-%systemd_postun %{_name}.serivce
+%systemd_postun %{name}.serivce
 
 %preun
-%systemd_preun %{_name}.serivce
+%systemd_preun %{name}.serivce
 
 %postun
-%systemd_postun %{_name}.serivce
+%systemd_postun %{name}.serivce
 
 %changelog
-* Wed Feb 6 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 3.1.0-1
+* Tue Dec 17 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 1332.0.0-1
+- Fix service file
+- Actually use the created user
+- Change service and executable to reflect the SIMP ownership so that we don't
+  conflict with other packages later
+- Ensure that the user account can use the next available system account ID
+
+* Wed Feb 6 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 1332.0.0-0
 - Updated for release to SIMP Project
 
-* Mon Dec 24 2018 Michael Morrone <michael.morrone@onyxpoint.com> - 3.1.0-0
-- Updated for new upstream release
-
-* Mon Apr 9 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 3.0.3-3
+* Mon Apr 9 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1332.0.0-0
 - Tweak RPM for building EL7 RPMs
 
 * Tue Dec 12 2017 XXX <x.x@x.x> - 1119.0.0-0


### PR DESCRIPTION
- Fix service file
- Actually use the created user
- Change service and executable to reflect the SIMP ownership so that we don't
  conflict with other packages later
- Ensure that the user account can use the next available system account ID

SIMP-7299 #commment Update simp-tpm2-simulator RPM for EL8